### PR TITLE
Fix: Export createWorkerBox function separately in addition to default export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 let workerBoxCount = 0;
-function createWorkerBox (scriptUrl, options) {
+export function createWorkerBox (scriptUrl, options) {
   options = {
     appendVersion: true,
     randomiseSubdomain: false,


### PR DESCRIPTION
I exported the createWorkerBox in the TypeScript typings but forgot to export it in the JavaScript file. This is a fix for that.