### PR TITLE
Fix the ignore pattern for dist directory to avoid infinite build loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ npm run start
 
 ### Run the tests
 
-Start a local server and run the tests:
+Build the server side component and run the tests:
 
 ```
-npm start&
+npm run build
 npm test
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,12 @@ npm run start
 ```
 
 ### Run the tests
+
+Start a local server and run the tests:
+
 ```
-npm run test
+npm start&
+npm test
 ```
 
 Visit https://0.0.0.0:8000 in your browser.

--- a/build.js
+++ b/build.js
@@ -41,7 +41,7 @@ if (isWatching) {
   const debouncedBuild = debounce(build, 300);
   chokidar.watch(
     ['./utils/*', './lib/*', './server'], {
-      ignored: ['**/dist']
+      ignored: ['**/dist/**']
     }).on('all', (why, what) => {
     console.log(new Date(), why, what);
     debouncedBuild();


### PR DESCRIPTION
When running `npm start`:

```
➜  workerbox git:(wyldemaster) npm start

> workerboxjs@4.0.3 start
> node build.js --watch & servatron --http2 --port 8002 --directory server/dist

Web server running: https://0.0.0.0:8002
2022-11-23T09:30:50.124Z addDir server
2022-11-23T09:30:50.129Z add server/index.html
2022-11-23T09:30:50.129Z add server/worker.js
2022-11-23T09:30:50.130Z add lib/argsToString.js
2022-11-23T09:30:50.131Z add lib/createCallbackStore.js
2022-11-23T09:30:50.131Z add lib/generateUniqueId.js
2022-11-23T09:30:50.131Z add lib/index.d.ts
2022-11-23T09:30:50.131Z add lib/index.js
2022-11-23T09:30:50.131Z add lib/scopeToString.js
2022-11-23T09:30:50.131Z add lib/stringToArgs.js
2022-11-23T09:30:50.131Z add lib/stringToScope.js
2022-11-23T09:30:50.432Z rebuilding...
{ errors: [], warnings: [] }
2022-11-23T09:30:50.472Z add server/dist/index.html
2022-11-23T09:30:50.472Z change server/dist/index.html
2022-11-23T09:30:50.772Z rebuilding...
{ errors: [], warnings: [] }
2022-11-23T09:30:50.806Z change server/dist/index.html
2022-11-23T09:30:51.108Z rebuilding...
```

Keeps rebuilding forever. By changing the ignore pattern as in this Pull Request, the watch mode seems to work correctly.