### PR TITLE
Fix argument encoding

### DIFF
--- a/lib/argsToString.js
+++ b/lib/argsToString.js
@@ -1,17 +1,7 @@
-import scopeToString from './scopeToString.js';
+import encodeArg from './encodeArg.js';
 
 function argsToString (args, addCallback, runCallback) {
-  const newArgs = [];
-  for (const arg of args) {
-    if (typeof arg === 'function') {
-      newArgs.push(['callback', addCallback(arg)]);
-    } else if (typeof arg === 'object') {
-      newArgs.push(['object', scopeToString(arg, addCallback, runCallback)]);
-    } else {
-      newArgs.push(['literal', arg]);
-    }
-  }
-  return JSON.stringify(newArgs);
+  return JSON.stringify(encodeArg(args, addCallback, runCallback));
 }
 
 export default argsToString;

--- a/lib/decodeArg.js
+++ b/lib/decodeArg.js
@@ -1,0 +1,23 @@
+import argsToString from "./argsToString";
+
+function decodeArg(arg, addCallback, runCallback) {
+  if (arg[0] === 'callback') {
+    return (...args) => runCallback(
+      arg[1],
+      argsToString(args, addCallback, runCallback)
+    );    
+  } else if (arg[0] === 'array') {
+    return arg[1].map(arg => decodeArg(arg, addCallback, runCallback))
+  } else if (arg[0] === 'object') {
+    const decodedArg = {}
+    for (const key in arg[1]) {
+      decodedArg[key] = decodeArg(arg[1][key], addCallback, runCallback)
+    }
+    return decodedArg
+  } else if (arg[0] === 'literal') {
+    return arg[1]
+  } else {
+    throw Error(`Unexpected arg type: ${arg[0]}`)
+  }
+}
+export default decodeArg

--- a/lib/encodeArg.js
+++ b/lib/encodeArg.js
@@ -1,0 +1,16 @@
+function encodeArg(arg, addCallback, runCallback) {
+  if (typeof arg === 'function') {
+    return ['callback', addCallback(arg)];
+  } else if (arg instanceof Array) {
+    return ['array', arg.map(arg => encodeArg(arg, addCallback, runCallback))];
+  } else if (typeof arg === 'object') {
+    const newArg = {}
+    for (const key in arg) {
+      newArg[key] = encodeArg(arg[key], addCallback, runCallback)
+    }
+    return ['object', newArg];
+  } else {
+    return ['literal', arg];
+  }
+}
+export default encodeArg

--- a/lib/scopeToString.js
+++ b/lib/scopeToString.js
@@ -1,15 +1,7 @@
+import encodeArg from "./encodeArg";
+
 function scopeToString (scope, addCallback, runCallback) {
-  const newScope = {};
-  for (const key in scope) {
-    if (typeof scope[key] === 'function') {
-      newScope[key] = ['callback', addCallback(scope[key])];
-    } else if (typeof scope[key] === 'object') {
-      newScope[key] = ['object', scopeToString(scope[key], addCallback, runCallback)];
-    } else {
-      newScope[key] = ['literal', scope[key]];
-    }
-  }
-  return JSON.stringify(newScope);
+  return JSON.stringify(encodeArg(scope || {}, addCallback, runCallback));
 }
 
 export default scopeToString;

--- a/lib/stringToArgs.js
+++ b/lib/stringToArgs.js
@@ -1,25 +1,7 @@
-import argsToString from './argsToString.js';
-import stringToScope from './stringToScope.js';
+import decodeArg from './decodeArg.js';
 
 function stringToArgs (args, addCallback, runCallback) {
-  args = JSON.parse(args);
-
-  const newArgs = [];
-  for (const arg of args) {
-    if (arg[0] === 'callback') {
-      const fn = (...args) => runCallback(
-        arg[1],
-        argsToString(args, addCallback)
-      );
-      newArgs.push(fn);
-    } else if (arg[0] === 'object') {
-      newArgs.push(stringToScope(arg[1], addCallback, runCallback));
-    } else {
-      newArgs.push(arg[1]);
-    }
-  }
-
-  return newArgs;
+  return decodeArg(JSON.parse(args), addCallback, runCallback)
 }
 
 export default stringToArgs;

--- a/lib/stringToScope.js
+++ b/lib/stringToScope.js
@@ -1,25 +1,7 @@
-import argsToString from './argsToString.js';
+import decodeArg from './decodeArg.js';
 
 function stringToScope (object, addCallback, runCallback) {
-  object = JSON.parse(object);
-  const newObject = {};
-  for (const key in object) {
-    if (object[key][0] === 'callback') {
-      const fn = (...args) => {
-        return runCallback(
-          object[key][1],
-          argsToString(args, addCallback)
-        );
-      };
-      newObject[key] = fn;
-    } else if (object[key][0] === 'object') {
-      newObject[key] = stringToScope(object[key][1], addCallback, runCallback);
-    } else {
-      newObject[key] = object[key][1];
-    }
-  }
-
-  return newObject;
+  return decodeArg(JSON.parse(object), addCallback, runCallback);  
 }
 
 export default stringToScope;

--- a/test/suite.js
+++ b/test/suite.js
@@ -12,6 +12,15 @@ test('simple evaluation', async (t) => {
   t.ok(result === 2, `${result} should equal 2`);
 });
 
+test('returning an array', async (t) => {
+  t.plan(1);
+
+  const { run } = await createWorkerBox(serverUrl, { appendVersion: false });
+  const result = await run('return [1]');
+
+  t.deepEqual(result, [1], `${result} should equal [1]`);
+});
+
 test('consecutive runs work', async (t) => {
   t.plan(2);
 
@@ -203,6 +212,49 @@ test('callback as a function can return a value', async (t) => {
 
   t.equal(await storedCallback(), 'worked');
 });
+
+import argsToString from "../lib/argsToString"
+import stringToArgs from "../lib/stringToArgs"
+import scopeToString from '../lib/scopeToString.js';
+import stringToScope from '../lib/stringToScope';
+
+test('argsToString and stringToArgs', async (t) => {
+  input = [{
+    foo: "bar",
+    nested: {
+      "asdf": "qwer"
+    },
+    array: [
+      1,
+      {
+        "three": 3
+      }
+    ]
+  }]
+
+  const stringified = argsToString(input, f => f, f => { throw Error("runCallback should not be called") })
+  const result = stringToArgs(stringified)
+  t.deepEqual(result, input, `Expected ${JSON.stringify(result)} to equal ${JSON.stringify(input)}`)
+})
+
+test('scopeToString and stringToScope', async (t) => {
+  input = {
+    foo: "bar",
+    nested: {
+      "asdf": "qwer"
+    },
+    array: [
+      1,
+      {
+        "three": 3
+      }
+    ]
+  }
+
+  const stringified = scopeToString(input, f => f, f => { throw Error("runCallback should not be called") })
+  const result = stringToScope(stringified)
+  t.deepEqual(result, input, `Expected ${JSON.stringify(result)} to equal ${JSON.stringify(input)}`)
+})
 
 run().then(stats => {
   console.log('$$TEST_BROWSER_CLOSE$$:' + JSON.stringify(stats));


### PR DESCRIPTION
I noticed that the argument/scope serialization mechanism failed for arrays. I rewrote it into a hopefully more maintainable shape.

Note: The serialization protocol is not compatible with the earlier one, so running with new client code against an older version of server will not work.