### PR TITLE
Make options optional in type definition

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,7 +2,7 @@ declare type WorkerBoxOptions = {
   appendVersion?: boolean;
 };
 declare type Scope = object;
-declare function createWorkerBox(scriptUrl: any, options: WorkerBoxOptions): Promise<{
+declare function createWorkerBox(scriptUrl: any, options?: WorkerBoxOptions): Promise<{
   run: (code: string, scope?: Scope) => Promise<any>;
   destroy: () => any;
 }>


### PR DESCRIPTION
They are in fact optional in the javascript and are omitted in the README.md example.

On a quick try though, the tests just hang without the `{ appendVersion: false }` options, so not sure what to think about this.