### PR TITLE
Add .js suffix to all local imports

### DIFF
--- a/lib/decodeArg.js
+++ b/lib/decodeArg.js
@@ -1,4 +1,4 @@
-import argsToString from './argsToString';
+import argsToString from './argsToString.js';
 
 function decodeArg (arg, addCallback, runCallback) {
   if (arg[0] === 'callback') {

--- a/lib/scopeToString.js
+++ b/lib/scopeToString.js
@@ -1,4 +1,4 @@
-import encodeArg from './encodeArg';
+import encodeArg from './encodeArg.js';
 
 function scopeToString (scope, addCallback, runCallback) {
   return JSON.stringify(encodeArg(scope || {}, addCallback, runCallback));


### PR DESCRIPTION
Seems that the lack thereof breaks Next.js application build, and possibly some other builds as well.

As a distraction, Next.js development server doesn't have problems with these imports.

Anyway, I'd say it doesn't hurt to go with the most compatible option.