### PR TITLE
Throw on callback error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ export async function createWorkerBox (scriptUrl, options) {
   }
 
   if (options.appendVersion) {
-    scriptUrl = scriptUrl + '/v5.2.0/';
+    scriptUrl = scriptUrl + '/v5.3.0/';
   }
 
   try {
@@ -58,12 +58,14 @@ export async function createWorkerBox (scriptUrl, options) {
   const callbacks = createCallbackStore();
 
   const run = (id, args) =>
-    new Promise(resolve => {
-      instance.postMessage(['callback', { id, args, resolve: callbacks.add(resolve) }]);
+    new Promise((resolve, reject) => {
+      instance.postMessage(['callback', {
+        id, args, resolve: callbacks.add(resolve), reject: callbacks.add(reject)
+      }]);
     });
 
   const instance = await createWorkerboxInstance(scriptUrl.href, async message => {
-    const [action, { id, args, resolve }] = message.data;
+    const [action, { id, args, resolve, reject }] = message.data;
 
     const parsedArgs = stringToArgs(args, callbacks.add, run);
 
@@ -82,8 +84,12 @@ export async function createWorkerBox (scriptUrl, options) {
       return;
     }
 
-    const result = await fn(...parsedArgs);
-    instance.postMessage(['callback', { id: resolve, args: argsToString([result], callbacks.add, run) }]);
+    try {
+      const result = await fn(...parsedArgs);
+      instance.postMessage(['callback', { id: resolve, args: argsToString([result], callbacks.add, run) }]);
+    } catch (error) {
+      instance.postMessage(['callback', { id: reject, args: argsToString([error.message], callbacks.add, run) }]);
+    }
   });
 
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workerboxjs",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "workerboxjs",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "license": "MIT",
       "devDependencies": {
         "@markwylde/ftp-deploy": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workerboxjs",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "type": "module",
   "description": "A secure sandbox to execute untrusted user JavaScript, in a web browser, without any risk to your own domain/site/page.",
   "main": "lib/index.js",

--- a/server/worker.js
+++ b/server/worker.js
@@ -11,6 +11,22 @@ async function scopedEval (context, expr) {
   return evaluator.apply(null, [...Object.values(context)]);
 }
 
+const getStack = (error, slice) => {
+  const lines = error.stack.split('\n');
+  const stack = [
+    lines[0],
+    ...lines
+      .filter(line => line.includes('(eval at scopedEval'))
+      .map(line => {
+        const splitted = line.split('(eval at scopedEval (');
+        const [, mixedPosition] = line.split('<anonymous>');
+        const [, lineNumber, charNumber] = mixedPosition.slice(0, -1).split(':');
+        return `${splitted[0]}(<sandbox>:${lineNumber - 3}:${charNumber})`
+      })
+  ].slice(0, slice).join('\n');
+  return stack;
+}
+
 self.addEventListener('message', async (event) => {
   const port = event.ports[0];
 
@@ -22,7 +38,7 @@ self.addEventListener('message', async (event) => {
 
   port.onmessage = async event => {
     const [action, message] = event.data;
-    const { id, errorId, code, scope, args, resolve } = message;
+    const { id, errorId, code, scope, args, resolve, reject } = message;
 
     if (action === 'execute') {
       const parsedScope = stringToScope(scope, callbacks.add, run);
@@ -33,18 +49,7 @@ self.addEventListener('message', async (event) => {
         port.postMessage(['return', { id, args: argsToString([result], callbacks.add, run) }]);
       } catch (error) {
         try {
-          const lines = error.stack.split('\n');
-          const stack = [
-            lines[0],
-            ...lines
-              .filter(line => line.includes('(eval at scopedEval'))
-              .map(line => {
-                const splitted = line.split('(eval at scopedEval (');
-                const [, mixedPosition] = line.split('<anonymous>');
-                const [, lineNumber, charNumber] = mixedPosition.slice(0, -1).split(':');
-                return `${splitted[0]}(<sandbox>:${lineNumber - 3}:${charNumber})`
-              })
-          ].slice(0, -1).join('\n');
+          const stack = getStack(error, -1);
           port.postMessage(['error', { id: errorId, args: argsToString([stack || error.message], callbacks.add, run) }]);
         } catch (error2) {
           port.postMessage(['error', { id: errorId, args: argsToString([error.message], callbacks.add, run) }]);
@@ -59,8 +64,13 @@ self.addEventListener('message', async (event) => {
       if (!fn) {
         return;
       }
-      const result = await fn(...parsedArgs);
-      port.postMessage(['return', { id: resolve, args: argsToString([result], callbacks.add, run) }]);
+      try {
+        const result = await fn(...parsedArgs);
+        port.postMessage(['return', { id: resolve, args: argsToString([result], callbacks.add, run) }]);
+      } catch (error) {
+        const stack = getStack(error);
+        port.postMessage(['error', { id: reject, args: argsToString([stack || error.message], callbacks.add, run) }]);
+      }
     }
   };
 });

--- a/test/suite.js
+++ b/test/suite.js
@@ -165,6 +165,24 @@ test('syntax error throws', async (t) => {
     });
 });
 
+test('syntax error throws inside function', async (t) => {
+  t.plan(1);
+
+  const { run } = await createWorkerBox(serverUrl, { appendVersion: false });
+
+  const result = await run(`
+    return {
+      add: (a, b) => {
+        ohno();
+      }
+    }
+  `);
+
+  result.add().catch(error => {
+    t.equal(error.message, 'ReferenceError: ohno is not defined\n    at add (<sandbox>:3:9)');
+  });
+});
+
 test('runtime error throws', async (t) => {
   t.plan(1);
 


### PR DESCRIPTION
Currently if you throw an error on the initial `run` call, the promise will throw and you will get a nice stack traced error explaining what went wrong.

However, if you execute a callback later on, it will fail silently.

This PR fixes the issue.

Meaning the following:

```javascript
const result = await run(`
  return {
    somethingBroken: () => {
      ohno(); // ohno is not defined
    }
  }
`);

result.somethingBroken()
```

Will reject with
```
ReferenceError: ohno is not defined
    at add (<sandbox>:3:9)');
```
